### PR TITLE
Fix Bug. treeLightObj needs to be multiplied by scaledRatio not slide…

### DIFF
--- a/Assets/Scripts/UIController.cs
+++ b/Assets/Scripts/UIController.cs
@@ -309,7 +309,7 @@ namespace ARChristmas
         private void AdjustLightToScaling(float sliderVal) 
         {  
             var scaledRatio = sliderVal / treeDefaultScale; 
-            treeLightsObj.transform.localScale = Vector3.one * sliderVal;
+            treeLightsObj.transform.localScale = Vector3.one * scaledRatio;
             foreach( var light in treeLights )
             {
                 light.range = scaledRatio;


### PR DESCRIPTION
…rVal.

sliderVal is just input value from slider.
scaledRatio is how much scaled up or down compared to the default size.
And the scale of treeLightObj is depending on the scaledRatio.